### PR TITLE
Be able to split out functionality in the pipeline.

### DIFF
--- a/etc/proxy-server.conf-sample
+++ b/etc/proxy-server.conf-sample
@@ -1,10 +1,19 @@
 # Example of changes needed to swift's proxy-server.conf
 [pipeline:main]
-pipeline = healthcheck cache tempauth sos proxy-server
+pipeline = healthcheck cache sos-cdn tempauth sos-manage proxy-server
 
-[filter:sos]
+[filter:sos-cdn]
 use = egg:sos#sos
 sos_conf = /etc/swift/sos.conf
 set log_name = python-sos
 set log_facility = LOG_LOCAL6
 set log_level = INFO
+valid_request_types = SOS_ORIGIN
+
+[filter:sos-manage]
+use = egg:sos#sos
+sos_conf = /etc/swift/sos.conf
+set log_name = python-sos
+set log_facility = LOG_LOCAL6
+set log_level = INFO
+valid_request_types = SOS_DB, SOS_ADMIN


### PR DESCRIPTION
After SLO and DLO were split out into middleware it is necessary
that the origin side of sos be before slo and dlo in the pipeline
while the origin management be behind auth. Here is an example
of the new pipeline:

pipeline = healthcheck proxy-logging-l cache sos-cdn slo ratelimit formpost tempurl tempauth account-quotas sos-manage staticweb proxy-logging proxy-server

[filter:sos-cdn]
use = egg:sos#sos
set log_name = python-sos
set log_facility = LOG_LOCAL6
set log_level = INFO
valid_request_types = SOS_ORIGIN
sos_conf = /etc/swift/sos.conf

[filter:sos-manage]
use = egg:sos#sos
set log_name = python-sos
set log_facility = LOG_LOCAL6
set log_level = INFO
valid_request_types = SOS_DB, SOS_ADMIN
sos_conf = /etc/swift/sos.conf
