### PR TITLE
registered origin constraints with /info

### DIFF
--- a/etc/sos.conf-sample
+++ b/etc/sos.conf-sample
@@ -13,7 +13,7 @@ hash_path_suffix = sos_suffix
 #origin_prefix = /origin/
 #default_ttl = 259200
 #min_ttl = 900
-#max_ttl = 3155692600
+#max_ttl = 31536000
 #max_cdn_file_size = 10737418240
 #number_dns_shards = 100
 # Enable DELETE method


### PR DESCRIPTION
min_ttl, max_ttl, default_ttl, and max_cdn_file_size are now
exposed in the /info endpoint under the 'cdn_origin' key.

In order to keep only one place for setting the default values
in the code, the defaults for these variables is set in a constant.

A functional test was added to check that these values exist and
return something castable to an int.

Updated the sample config to reflect the default value set by the code.
