### PR TITLE
Allow ability to forward origin

### DIFF
--- a/etc/sos.conf-sample
+++ b/etc/sos.conf-sample
@@ -38,6 +38,11 @@ hash_path_suffix = sos_suffix
 # set this to blank if you do not want to force an extra header to delete
 # the cdn container
 # extra_header_for_deletes = x-remove-cdn-container
+#
+# Whether or not to forward HTTP_ORIGIN header down into the proxy server.
+# If you are running a pre-strict_cors_mode version of swift you will get
+# bad behavior if you forward the origin down.
+# forward_origin = true
 
 [incoming_url_regex]
 # These regular expressions will be used to parse to cdn request urls to get

--- a/sos/origin.py
+++ b/sos/origin.py
@@ -217,6 +217,8 @@ class OriginBase(object):
         self.log_access_requests = conf.get('log_access_requests', 't') in \
             TRUE_VALUES
         self.number_dns_shards = int(conf.get('number_dns_shards', 100))
+        self.forward_origin = conf.get('forward_origin', 't') in \
+            TRUE_VALUES
         if not self.hash_suffix:
             raise InvalidConfiguration('Please provide a hash_path_suffix')
 
@@ -462,6 +464,8 @@ class CdnHandler(OriginBase):
             headers = self._getCdnHeaders(req)
             env['swift.source'] = 'SOS'
             env['swift.leave_relative_location'] = True
+            if not self.forward_origin:
+                env.pop('HTTP_ORIGIN', None)
             resp = make_pre_authed_request(
                 env, req.method, swift_path, headers=headers,
                 agent='SwiftOrigin', swift_source='SOS').get_response(self.app)


### PR DESCRIPTION
If you are using a pre-strict_cors_mode version of swift and you
forward the origin then it doesn't work well for a CDN. Pre strict_mode
you could set a container access-control-allow-origin:\* and it would
return the incoming Origin header instead of *. That mean the first
Origin would get cached on the edge and it would block out incoming
Origins even though the intention was to allow *.
